### PR TITLE
Fix twitter meta description

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -35,7 +35,7 @@ export default function App({ Component, pageProps }: AppProps) {
         />
         <meta
           name="twitter:description"
-          content="ビンゴのようにランダムに名前を大きく表示するWeアプリです。入力した名前は外部サーバーに送信されず、ローカルに保存されます。"
+          content="ビンゴのようにランダムに名前を大きく表示するWebアプリです。入力した名前は外部サーバーに送信されず、ローカルに保存されます。"
         />
         <meta
           name="twitter:image"


### PR DESCRIPTION
## Summary
- restore the full text for `twitter:description`

## Testing
- `npm run lint` *(fails: `next` not found)*


------
https://chatgpt.com/codex/tasks/task_e_6841a20cb20c832391335a8495c0d0af